### PR TITLE
Corrected artifact ID of Sifter

### DIFF
--- a/sifter/0.4.1/pom.xml
+++ b/sifter/0.4.1/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.forgerock.commons.ui.libs</groupId>
-  <artifactId>sifter.js</artifactId>
+  <artifactId>sifter</artifactId>
   <version>0.4.1</version>
   <packaging>pom</packaging>
 


### PR DESCRIPTION
In the initial adding of the Sifter JS library I made a mistake in the artifact ID (appended `.js` to it). This PR corrects that.

I've already deleted the botched artifact from JFrog to prevent confusion.