### PR TITLE
Switch parent POMs and normalize license identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,12 @@ Follow these steps to add the new library to this project:
    ```
 2. Follow the prompts and provide relevant answers for the library you are
    adding. Most of the information typically comes from the library's project
-   information on GitHub. Be sure to answer `Y` at the end to create the
-   wrapper project.
+   information on GitHub.
+   
+   **Licenses should be named according to their 
+   [SPDX Identifier](https://spdx.org/licenses/)**.
+   
+   Be sure to answer `Y` at the end to create the wrapper project.
 3. Copy the minified / release-grade JS and/or CSS files for the library into
    the `LIBRARY-NAME/VERSION` folder.
 4. Customize the POM found at `LIBRARY-NAME/pom.xml`, where `LIBRARY-NAME` is

--- a/font-awesome/4.3.0/pom.xml
+++ b/font-awesome/4.3.0/pom.xml
@@ -14,7 +14,7 @@
    replaced by your own identifying information: "Portions copyright [year]
    [name of copyright owner]".
 
-   Copyright 2017 Wren Security.
+   Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -42,7 +42,7 @@
     </license>
 
     <license>
-      <name>SIL OFL 1.1</name>
+      <name>OFL-1.1</name>
       <url>http://scripts.sil.org/OFL</url>
       <distribution>repo</distribution>
       <comments>SIL OFL 1.1 Applies to all desktop and webfont files in the following directory: font-awesome/fonts/ @davegandy - http://fontawesome.io</comments>

--- a/font-awesome/4.5.0/pom.xml
+++ b/font-awesome/4.5.0/pom.xml
@@ -14,7 +14,7 @@
    replaced by your own identifying information: "Portions copyright [year]
    [name of copyright owner]".
 
-   Copyright 2017 Wren Security.
+   Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -42,7 +42,7 @@
     </license>
 
     <license>
-      <name>SIL OFL 1.1</name>
+      <name>OFL-1.1</name>
       <url>http://scripts.sil.org/OFL</url>
       <distribution>repo</distribution>
       <comments>SIL OFL 1.1 Applies to all desktop and webfont files in the following directory: font-awesome/fonts/ @davegandy - http://fontawesome.io</comments>

--- a/jquery.ba-dotimeout/1.0/pom.xml
+++ b/jquery.ba-dotimeout/1.0/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+   The contents of this file are subject to the terms of the Common Development
+   and Distribution License (the License). You may not use this file except in
+   compliance with the License.
+
+   You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License
+   for the specific language governing permission and limitations under the
+   License.
+
+   When distributing Covered Software, include this CDDL Header Notice in each
+   file and include the License file at legal/CDDLv1.0.txt. If applicable, add
+   the following below the CDDL Header, with the fields enclosed by brackets []
+   replaced by your own identifying information: "Portions copyright [year]
+   [name of copyright owner]".
+
+   Copyright 2017-2018 Wren Security.
+-->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
@@ -19,14 +36,14 @@
 
   <licenses>
     <license>
-      <name>MIT License</name>
+      <name>MIT</name>
       <url>https://github.com/cowboy/jquery-dotimeout/blob/v1.0/LICENSE-MIT</url>
       <distribution>repo</distribution>
       <comments>Copyright (c) 2010 "Cowboy" Ben Alman</comments>
     </license>
 
     <license>
-      <name>GPL-2.0</name>
+      <name>GPL-2.0-or-later</name>
       <url>https://github.com/cowboy/jquery-dotimeout/blob/v1.0/LICENSE-GPL</url>
       <distribution>repo</distribution>
       <comments>Copyright (c) 2010 "Cowboy" Ben Alman</comments>

--- a/jquery.nesting-sortable/0.9.12/pom.xml
+++ b/jquery.nesting-sortable/0.9.12/pom.xml
@@ -35,8 +35,8 @@
 
   <licenses>
     <license>
-      <name>Modified BSD</name>
-      <url>http://www.xfree86.org/3.3.6/COPYRIGHT2.html</url>
+      <name>BSD-3-Clause</name>
+      <url>https://github.com/johnny/jquery-sortable/blob/master/LICENSE</url>
       <distribution>repo</distribution>
       <comments>Copyright (c) 2012 Jonas von Andrian</comments>
     </license>

--- a/microplugin/0.0.3/pom.xml
+++ b/microplugin/0.0.3/pom.xml
@@ -14,7 +14,7 @@
    replaced by your own identifying information: "Portions copyright [year]
    [name of copyright owner]".
 
-   Copyright 2017 Wren Security.
+   Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -35,7 +35,7 @@
 
   <licenses>
     <license>
-      <name>Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <!-- There is no LICENSE file in the repo. License is stated in readme file. -->
       <url>https://github.com/brianreavis/sifter.js/blob/master/README.md</url>
       <distribution>repo</distribution>

--- a/moment/2.8.1/pom.xml
+++ b/moment/2.8.1/pom.xml
@@ -14,7 +14,7 @@
    replaced by your own identifying information: "Portions copyright [year]
    [name of copyright owner]".
 
-   Copyright 2017 Wren Security.
+   Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -35,7 +35,7 @@
 
   <licenses>
     <license>
-      <name>MIT License</name>
+      <name>MIT</name>
       <url>https://github.com/moment/moment/blob/2.8.1/LICENSE</url>
       <distribution>repo</distribution>
       <comments>Copyright (c) 2011-2014 Tim Wood, Iskren Chernev, Moment.js contributors</comments>

--- a/pom.xml
+++ b/pom.xml
@@ -14,14 +14,14 @@
    replaced by your own identifying information: "Portions copyright [year]
    [name of copyright owner]".
 
-   Copyright 2017 Wren Security.
+   Copyright 2017-2018 Wren Security.
 --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.forgerock</groupId>
-    <artifactId>forgerock-parent</artifactId>
-    <version>2.0.7</version>
+    <groupId>org.wrensecurity</groupId>
+    <artifactId>wrensec-parent</artifactId>
+    <version>2.2.0</version>
   </parent>
 
   <groupId>org.wrensecurity.commons.ui.libs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
    [name of copyright owner]".
 
    Copyright 2017-2018 Wren Security.
---><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -77,12 +77,14 @@
     <module>bootstrap-dialog</module>
     <module>bootstrap-tabdrop</module>
     <module>CodeMirror</module>
+    <module>dragula</module>
     <module>font-awesome</module>
     <module>form2js</module>
     <module>handlebars</module>
     <module>i18next</module>
     <module>jquery</module>
     <module>jquery.ba-dotimeout</module>
+    <module>jquery-cron</module>
     <module>jquery.placeholder</module>
     <module>jquery.nesting-sortable</module>
     <module>js2form</module>
@@ -91,6 +93,7 @@
     <module>lodash</module>
     <module>microplugin</module>
     <module>moment</module>
+    <module>moment-timezone-with-data</module>
     <module>qrcode</module>
     <module>qunit</module>
     <module>r</module>
@@ -102,9 +105,6 @@
     <module>squire</module>
     <module>titatoggle</module>
     <module>xdate</module>
-    <module>jquery-cron</module>
-    <module>dragula</module>
-    <module>moment-timezone-with-data</module>
   </modules>
 
   <properties>

--- a/r/2.1.10/pom.xml
+++ b/r/2.1.10/pom.xml
@@ -14,7 +14,7 @@
    replaced by your own identifying information: "Portions copyright [year]
    [name of copyright owner]".
 
-   Copyright 2017 Wren Security.
+   Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -35,7 +35,7 @@
 
   <licenses>
     <license>
-      <name>BSD</name>
+      <name>BSD-3-Clause</name>
       <url>https://github.com/jrburke/r.js/blob/2.1.10/LICENSE</url>
       <distribution>repo</distribution>
       <comments>Copyright (c) 2010-2011, The Dojo Foundation</comments>

--- a/sifter/0.4.1/pom.xml
+++ b/sifter/0.4.1/pom.xml
@@ -14,7 +14,7 @@
    replaced by your own identifying information: "Portions copyright [year]
    [name of copyright owner]".
 
-   Copyright 2017 Wren Security.
+   Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -35,7 +35,7 @@
 
   <licenses>
     <license>
-      <name>Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <!-- There is no LICENSE file in the repo. License is stated in readme file. -->
       <url>https://github.com/brianreavis/sifter.js/blob/master/README.md</url>
       <distribution>repo</distribution>

--- a/sinon/1.15.4/pom.xml
+++ b/sinon/1.15.4/pom.xml
@@ -14,7 +14,7 @@
    replaced by your own identifying information: "Portions copyright [year]
    [name of copyright owner]".
 
-   Copyright 2017 Wren Security.
+   Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -35,7 +35,7 @@
 
   <licenses>
     <license>
-      <name>BSD</name>
+      <name>BSD-3-Clause</name>
       <url>https://github.com/sinonjs/sinon/blob/v1.15.4/LICENSE</url>
       <distribution>repo</distribution>
       <comments>Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no</comments>

--- a/titatoggle/1.2.6/pom.xml
+++ b/titatoggle/1.2.6/pom.xml
@@ -14,7 +14,7 @@
    replaced by your own identifying information: "Portions copyright [year]
    [name of copyright owner]".
 
-   Copyright 2017 Wren Security.
+   Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -35,7 +35,7 @@
 
   <licenses>
     <license>
-      <name>BSD</name>
+      <name>BSD-2-Clause</name>
       <url>http://opensource.org/licenses/BSD-2-Clause</url>
       <distribution>repo</distribution>
       <comments>https://github.com/kleinejan/titatoggle/blob/v1.2.6/package.json</comments>

--- a/xdate/0.8/pom.xml
+++ b/xdate/0.8/pom.xml
@@ -14,7 +14,7 @@
    replaced by your own identifying information: "Portions copyright [year]
    [name of copyright owner]".
 
-   Copyright 2017 Wren Security.
+   Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -42,7 +42,7 @@
     </license>
 
     <license>
-      <name>GPL</name>
+      <name>GPL-2.0-or-later</name>
       <url>https://github.com/arshaw/xdate/blob/v0.8/GPL-LICENSE.txt</url>
       <distribution>repo</distribution>
       <comments>Copyright (c) 2011 Adam Shaw, http://arshaw.com/xdate/</comments>


### PR DESCRIPTION
- Upgrades to `wrensec-parent-2.2.0`, to fix PGP verification.
- Standardizes license identifiers to follow [SPDX](https://spdx.org/license-list).